### PR TITLE
Fix aggregation of neighboring prefixes

### DIFF
--- a/inc/aggregate.inc
+++ b/inc/aggregate.inc
@@ -94,6 +94,11 @@ function aggregate_routes($routefile)
     $current = explode("/", rtrim($addresses[0]));
     for ($i = 1; $i < $count; $i++)
     {
+      /** Since we're deleting from the same array we're looping through, we can
+          end up trying to access prefixes that no longer exist.  Don't do that in order
+          to avoid warnings */
+      if (!isset($addresses[$i])) continue;
+
       $next = explode("/", rtrim($addresses[$i]));
       /* If we picked up two different IP versions we can move on */
       if (_ip_version($current[0]) != _ip_version($next[0]))

--- a/inc/aggregate.inc
+++ b/inc/aggregate.inc
@@ -17,7 +17,7 @@ function aggregate_routes($routefile)
   }
 
   for ($i = 0; $i < count($addresses); $i++)
-  {  
+  {
     if (_ip_version($addresses[$i]) == '6')
     {
       /* normalize v6 notation */
@@ -48,7 +48,7 @@ function aggregate_routes($routefile)
       /* Mask both routes and look for overlaps */
       $a = ip2long($current[0]) & (0xFFFFFFFF << (32 - $current[1]));
       $b = ip2long($next[0]) & (0xFFFFFFFF << (32 - $current[1]));
-      if ($a == $b) 
+      if ($a == $b)
       {
         status(STATUS_NOTICE, "Removing {$next[0]}/{$next[1]}, fits into: {$current[0]}/{$current[1]}");
         unset($addresses[$i]);
@@ -57,14 +57,14 @@ function aggregate_routes($routefile)
       {
         $current = $next;
       }
-    }      
+    }
     /* If both IP's are v6 */
     elseif (_ip_version($current[0]) == '6' and _ip_version($next[0]) == '6')
     {
       /* Mask both routes and look for overlaps */
       $a = _v6_to_network($current[0], $current[1] );
       $b = _v6_to_network($next[0], $current[1]);
-      if ($a == $b) 
+      if ($a == $b)
       {
         status(STATUS_NOTICE, "Removing {$next[0]}/{$next[1]}, fits into: {$current[0]}/{$current[1]}");
         unset($addresses[$i]);
@@ -75,7 +75,7 @@ function aggregate_routes($routefile)
       }
     }
 
-    else 
+    else
     {
       /* whoopsie */
       status(STATUS_ERROR, "Something went terribly wrong while removing overlapping prefixes, aborting.");
@@ -106,25 +106,27 @@ function aggregate_routes($routefile)
         /* If the masks are the same, mask both routes with mask-1 and look if those are identical */
         if ($current[1] == $next[1] )
         {
-          $a = ip2long($current[0]) & (0xFFFFFFFF << (32 - $current[1] - 1));
-          $b = ip2long($next[0]) & (0xFFFFFFFF << (32 - $next[1] - 1));
-          if ($a == $b) 
+          /* since we're subtracting the current mask from 32, we need to *increment* the current
+             mask by 1.  Otherwise, we end up turning a /24 into a /25, which will never work for aggregation */
+          $a = ip2long($current[0]) & (0xFFFFFFFF << (32 - $current[1] + 1));
+          $b = ip2long($next[0]) & (0xFFFFFFFF << (32 - $next[1] + 1));
+          if ($a == $b)
           {
             /* Remove both smaller prefixes and add the aggregted one */
             $ip_a = long2ip($a);
             $new_mask = $next[1] - 1;
-            $new_prefox = $ip_a .  "/" . $new_mask;
+            $new_prefix = $ip_a .  "/" . $new_mask;
             status(STATUS_WARNING, "Aggregating {$current[0]}/{$current[1]} and {$next[0]}/{$next[1]} into {$new_prefix}");
             unset($addresses[$i - 1]);
-            $addresses[$i] = "{$new_prefix}\n"; 
+            $addresses[$i] = "{$new_prefix}\n";
             $changes = 1;
           }
-          else 
+          else
           {
             $current = $next;
           }
         }
-        else 
+        else
         {
           $current = $next;
         }
@@ -137,27 +139,27 @@ function aggregate_routes($routefile)
         {
           $a = _v6_to_network($current[0], $current[1] - 1);
           $b = _v6_to_network($next[0], $next[1] - 1);
-          if ($a == $b) 
+          if ($a == $b)
           {
             /* Remove both smaller prefixes and add the aggregted one */
             $new_mask = $next[1] - 1;
             $new_prefix = $a .  "/" . $new_mask;
             status(STATUS_WARNING, "Aggregating {$current[0]}/{$current[1]} and {$next[0]}/{$next[1]} into {$new_prefix}");
             unset($addresses[$i - 1]);
-            $addresses[$i] = "{$new_prefix}\n"; 
+            $addresses[$i] = "{$new_prefix}\n";
             $changes = 1;
           }
-          else 
+          else
           {
             $current = $next;
           }
         }
-        else 
+        else
         {
           $current = $next;
         }
       }
-      else 
+      else
       {
         /* whoopsie */
         status(STATUS_ERROR, "Something went terribly wrong while aggregating prefixes, aborting.");
@@ -168,7 +170,7 @@ function aggregate_routes($routefile)
   }
 
   for ($i = 0; $i < count($addresses); $i++)
-  {  
+  {
     if (_ip_version($addresses[$i]) == '6')
     {
       /* compress v6 notation */
@@ -177,7 +179,7 @@ function aggregate_routes($routefile)
     }
   }
 
-  return $addresses; 
+  return $addresses;
 }
 
 ?>


### PR DESCRIPTION
This corrects the issue in #47.

Prior to this, IRRPT would take two prefixes like:

    2.99.146.0/24
    2.99.147.0/24

and turn them into

    2.99.146.0/25
    2.99.147.0/25

Then compare them.  They'd never be the same, so it would never figure out that they could be aggregated.  This was just a mistaken increment versus decrement.

That was masking another bug (simple type, 'new_prefox' instead of 'new_prefix')

There are also some whitespace changes here, this file had a lot of trailing whitespace