### PR TITLE
added ciscoxr to usage

### DIFF
--- a/bin/irrpt_pfxgen
+++ b/bin/irrpt_pfxgen
@@ -36,6 +36,7 @@ function usage($progname)
 	printf("  format       - The output format for a specific router type (default: %s)\n", $o_format);
 	printf("                 Currently supported values are:\n");
 	printf("                 cisco\n");
+        printf("                 ciscoxr\n");
 	printf("                 extreme\n");
 	printf("                 foundry\n");
 	printf("                 force10\n");


### PR DESCRIPTION
Hello.  This is a very minor fix.  I noticed the help for irrpt_pfxgen did not list support for IOS-XR.  I added ciscoxr.

~$ ./irrpt_pfxgen
Usage: ./irrpt_pfxgen [-h46] [-p pfxstr] [-p6 pfxstr_v6] [-l pfxlength] [-l6 pfxlength_v6] [-f format] <asn>
  pfxstr       - The prefix-list name format string (default: CUSTOMER:%d)
  pfxstr_v6    - The prefix-list name format string (default: CUSTOMERv6:%d)
  pfxlength    - The max length more-specific that will be allowed (default: 24)
  pfxlength_v6 - The max length more-specific that will be allowed for v6 (default: 48)
  format       - The output format for a specific router type (default: cisco)
                 Currently supported values are:
                 cisco
                 ciscoxr
                 extreme
                 foundry
                 force10
                 juniper
~$