### PR TITLE
typo in format value iosxr vs ciscoxr

### DIFF
--- a/inc/pfxlist.inc
+++ b/inc/pfxlist.inc
@@ -39,7 +39,7 @@ function pfxlist_generate($format, $asn, $pfxstr, $pfxstr_v6, $pfxlen, $pfxlen_v
 	    case 'cisco':
 		pfxlist_generate_cisco($pfxfile, $asn_number, $pfxstr, $pfxstr_v6, $pfxlen, $pfxlen_v6, $o_4, $o_6);
 		break;
-	    case 'iosxr':
+	    case 'ciscoxr':
 		pfxlist_generate_iosxr($pfxfile, $asn_number, $pfxstr, $pfxstr_v6, $pfxlen, $pfxlen_v6, $o_4, $o_6);
 		break;
 	    case 'juniper':


### PR DESCRIPTION
documented as `ciscoxr`. would work only with flag `bin/irrpt_pfxgen -f iosxr 42` Default value `$cfg['pfxgen']['default_format']	  = "ciscoxr"` wil be ignored