### PR TITLE
Fix to concat_files function

### DIFF
--- a/inc/utils.inc
+++ b/inc/utils.inc
@@ -70,7 +70,7 @@ function concat_files($src_file1, $src_file2, $dst_file) {
     }
     else { status(STATUS_INFO, "Warning: Unable to read $src_file1."); }
 
-    if(fwrite($dst_fp, $content_file1) === FALSE) {
+    if(fwrite($dst_fp, "$content_file1\n") === FALSE) {
         status(STATUS_INFO, "Warning: File content $src_file1 not written to $dst_file.");
     }
 


### PR DESCRIPTION
When generating .agg files with ASNs that have v4 and v6 prefixes, I was seeing that the last line in the .agg file did not contain a \n, resulting in the v6 address being appended to the line, resulting in .agg files that looked like this:

```
[irrpt]$ more db/11178.agg
8.20.178.0/23
8.20.186.0/23
8.20.190.0/24
64.213.37.0/24
64.215.212.0/24
139.180.18.0/23
141.193.147.0/24
141.193.222.0/23
168.245.150.0/24
192.156.251.0/242001:1900:3015::/48
```

This causes config file generation to be broken. Juniper example: 

```
policy-options {
    replace: policy-statement CUSTOMERv6:11178 {
        term prefixes {
            from {
                route-filter 192.156.251.0/242001:1900:3015::/48 prefix-length-range /242001-/48;
            }
            then next policy;
        }
        then reject;
    }
}
```

Adding a newline character to the concat_files function fixes this problem.