### PR TITLE
irrpt_objgrpgen: New tool for generating ciscoxr security object groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,25 @@ status data, not deploying configurations.
 
 Many other systems exist as well.
 
+### irrpt_objgrpgen
+
+    $ bin/irrpt_objgrpgen -h
+    Usage: bin/irrpt_objgrpgen [-h46] [-p pfxstr] [-p6 pfxstr_v6] [-f format] <asn>
+      pfxstr       - The prefix-list name format string (default: CUSTOMER:%d)
+      pfxstr_v6    - The prefix-list name format string (default: CUSTOMERv6:%d)
+      format       - The output format for a specific router type (default: cisco)
+                     Currently supported values are:
+		     ciscoxr
+
+Examples:
+
+    $ bin/irrpt_objgrpgen -f ciscoxr 42
+    ...
+
+Similar to the "pfxgen" tool, this generates router configuration for security
+object groups which are suitable for inclusion in an anti-spoofing access
+control list.  Currently only Cisco XR is supported.
+
 ### irrpt_list_prefixes
 
 Show prefixes for a given AS or AS-SET, in unaggregated or aggregated form.

--- a/bin/irrpt_objgrpgen
+++ b/bin/irrpt_objgrpgen
@@ -1,0 +1,97 @@
+#!/usr/bin/env php
+<?php
+
+$currentpath = dirname(realpath(__FILE__));
+require("{$currentpath}/../conf/irrpt.conf");
+require("{$currentpath}/../inc/objgrp.inc");
+require("{$currentpath}/../inc/ipv6.inc");
+require("{$currentpath}/../inc/status.inc");
+require("{$currentpath}/../inc/utils.inc");
+
+/* Load our defaults from the master config file */
+$o_grpstr	    = $cfg['objgrpgen']['default_grpstr'];
+$o_grpstr_v6        = $cfg['objgrpgen']['default_grpstr_v6'];
+$o_format	    = $cfg['objgrpgen']['default_format'];
+
+$o_4 = 0; /* Default to fetch both v4 and v6 by setting this to 0 */
+$o_6 = 0; /* Default to fetch both v4 and v6 by setting this to 0 */
+
+
+function usage($progname)
+{
+	global $o_grpstr;
+	global $o_grpstr_v6;
+	global $o_format;
+
+	printf("Usage: %s [-h46] [-p grpstr] [-p6 grpstr_v6] [-f format] <asn>\n",
+		$progname);
+	printf("  grpstr       - The object-group name format string (default: %s)\n", $o_grpstr);
+	printf("  grpstr_v6    - The object-group name format string (default: %s)\n", $o_grpstr_v6);
+	printf("  format       - The output format for a specific router type (default: %s)\n", $o_format);
+	printf("                 Currently supported values are:\n");
+        printf("                 ciscoxr\n");
+	exit(1);
+}
+
+
+/* Parse through the cmdline options. */
+for ($offset = 1; $offset < $_SERVER['argc']; $offset++) {
+	if (substr($_SERVER['argv'][$offset], 0, 1) != "-")
+		break;
+
+	switch($_SERVER['argv'][$offset]) {
+	    case "-h":
+	    case "--help":
+		usage($_SERVER['argv'][0]);
+
+	    case "-p":
+	    case "--grpstr":
+                $o_grpstr = $_SERVER['argv'][++$offset];
+		break;
+
+	    case "-p6":
+	    case "--grpstr_v6":
+                $o_grpstr_v6 = $_SERVER['argv'][++$offset];
+		break;
+
+      case "-4":
+      case "--4":
+    $o_4 = 1;
+    break;
+
+      case "-6":
+      case "--6":
+    $o_6 = 1;
+    break;
+
+	    case "-f":
+	    case "--format":
+                switch (strtolower($_SERVER['argv'][++$offset])) {
+		    case "ciscoxr":
+		    case "iosxr":
+			$o_format = "iosxr";
+			break;
+
+		    default:
+			printf("Unknown format, aborting.\n");
+			exit(1);
+		}
+
+		break;
+
+	}
+}
+
+/* Check for minimum number of args after cmdline */
+if (($_SERVER['argc'] - $offset) < 1)
+	usage($_SERVER['argv'][0]);
+
+$asn = $_SERVER['argv'][$offset+0];
+
+
+if (objgrp_generate($o_format, $asn, $o_grpstr, $o_grpstr_v6, $o_4, $o_6) < 0) {
+	printf("Error generating prefix-list, aborting.\n");
+	exit(1);
+}
+
+?>

--- a/conf/irrpt.conf
+++ b/conf/irrpt.conf
@@ -55,6 +55,10 @@ $cfg['pfxgen']['default_pfxlen']	  = "24";
 $cfg['pfxgen']['default_pfxlen_v6']	= "48";
 $cfg['pfxgen']['default_format']	  = "cisco";
 
+$cfg['objgrpgen']['default_grpstr']	  = "CUSTOMER:%d";
+$cfg['objgrpgen']['default_grpstr_v6']	= "CUSTOMERv6:%d";
+$cfg['objgrpgen']['default_format']	  = "ciscoxr";
+
 $cfg['update']['from']			= "eng@yourcompany.com";
 $cfg['update']['reply-to']		= "eng@yourcompany.com";
 $cfg['update']['subject']		= "[IRRPT] ";

--- a/inc/objgrp.inc
+++ b/inc/objgrp.inc
@@ -1,0 +1,106 @@
+<?php
+
+function objgrp_generate($format, $asn, $grpstr, $grpstr_v6, $o_4, $o_6)
+{
+	global $cfg;
+
+    if(!check_asn_arg($asn, $asn_number, $asn_string)) {
+        status(STATUS_ERROR, "Invalid ASN {$asn}");
+        return FALSE;
+    }
+
+	// only v4
+	if( $o_4 == 1 && $o_6 == 0 )
+	{
+		$file = $cfg['paths']['db'] . $asn_number . '.4' . $cfg['aggregate']['suffix'];
+	}
+	// only v6
+	elseif( $o_6 == 1 && $o_4 == 0 )
+	{
+		$file = $cfg['paths']['db'] . $asn_number . '.6' . $cfg['aggregate']['suffix'];
+	}
+	// v4 and v6
+	else
+	{
+		$file = $cfg['paths']['db'] . $asn_number . $cfg['aggregate']['suffix'];
+	}
+
+	if (!file_exists($file) || !is_readable($file)) {
+		status(STATUS_ERROR, "Cannot open IRRDB prefix list file {$file}");
+		return FALSE;
+	}
+
+	if (!($pfxfile = fopen($file, "r"))) {
+		status(STATUS_ERROR, "Cannot open IRRDB prefix list file {$file}");
+		return FALSE;
+	}
+
+	switch ($format) {
+	    case 'ciscoxr':
+		objgrp_generate_iosxr($pfxfile, $asn_number, $grpstr, $grpstr_v6, $o_4, $o_6);
+		break;
+	    default:
+		break;
+	}
+
+	fclose($pfxfile);
+}
+
+function objgrp_generate_iosxr($pfxfile, $asn, $grpstr, $grpstr_v6, $o_4, $o_6)
+{
+	$pfxname = sprintf($grpstr, $asn);
+	$pfxname_v6 = sprintf($grpstr_v6, $asn);
+	$pfx1st = 'Y';
+	$pfx1st_v6 = 'Y';
+	global $cfg;
+
+	printf("conf\n");
+  if( $o_4 == 1 && $o_6 == 0 )
+  {
+    printf("no object-group network ipv4 %s\n", $pfxname);
+  }
+  elseif( $o_6 == 1 && $o_4 == 0 )
+  {
+    printf("no object-group network ipv6 %s\n", $pfxname_v6);
+  }
+  else
+  {
+    printf("no object-group network ipv4 %s\n", $pfxname);
+    printf("no object-group network ipv6 %s\n", $pfxname_v6);
+  }
+
+	while (!feof($pfxfile)) {
+		if (!($line = rtrim(fgets($pfxfile, 64))))
+			continue;
+
+		$prefix = explode("/", rtrim($line));
+		if (preg_match('/:/', $prefix[0]) && $pfx1st == 'N')
+		{
+			printf("exit\n");
+			printf("object-group network ipv6 %s\n", $pfxname_v6);
+			$pfx1st_v6 = 'N';
+		}
+		elseif ($pfx1st_v6 == 'Y' && preg_match('/:/', $prefix[0]))
+		{
+			printf("object-group network ipv6 %s\n", $pfxname_v6);
+			$pfx1st_v6 = 'N';
+		}
+		elseif ($pfx1st == 'Y')
+		{
+			$pfx1st = 'N';
+    			printf("object-group network ipv4 %s\n", $pfxname);
+		}
+		printf("  %s/%d\n", $prefix[0], $prefix[1]);
+	}
+
+	if ($pfx1st == 'N' || $pfx1st_v6 == 'N')
+	{
+		printf("exit\n");
+	}
+	printf("commit\n");
+	printf("exit\n");
+
+	return 0;
+}
+
+?>


### PR DESCRIPTION
Hi, I have created a new tool, irrpt_objgrpgen, that creates ciscoxr object-groups based on the prefixes downloaded from the IRR.  It's entirely based on irrpt_pfxgen; most of the edits were to remove things like end-of-line commas, to rename variables where it seemed to make sense, and to simplify the way items are output.  I plan to use this to maintain our anti-spoofing ACLs.  