### PR TITLE
New http pull methode

### DIFF
--- a/bin/irrpt_pfxgen_http.php
+++ b/bin/irrpt_pfxgen_http.php
@@ -1,0 +1,45 @@
+<?php
+// SGR 4.12.2019
+header("Content-Type: text/plain");
+$currentpath = dirname(realpath(__FILE__));
+require("{$currentpath}/../conf/irrpt.conf");
+require("{$currentpath}/../inc/pfxlist.inc");
+require("{$currentpath}/../inc/ipv6.inc");
+require("{$currentpath}/../inc/status.inc");
+require("{$currentpath}/../inc/utils.inc");
+
+/* Load our defaults from the master config file */
+$o_pfxstr	    = $cfg['pfxgen']['default_pfxstr'];
+$o_pfxstr_v6  = $cfg['pfxgen']['default_pfxstr_v6'];
+$o_pfxlen	    = $cfg['pfxgen']['default_pfxlen'];
+$o_pfxlen_v6	= $cfg['pfxgen']['default_pfxlen_v6'];
+$o_format	    = $cfg['pfxgen']['default_format'];
+
+$o_4 = 0; /* Default to fetch both v4 and v6 by setting this to 0 */
+$o_6 = 0; /* Default to fetch both v4 and v6 by setting this to 0 */
+
+// parse the arg path
+$arg = explode("/", $_SERVER['QUERY_STRING']);
+
+// URI /<as_int> with default Format
+if (count($arg) == 1 & is_numeric($arg[0])) {
+	$asn = $arg[0];
+}
+// URI /<os>/<as_int>
+elseif (count($arg) == 2 & is_string($arg[0]) &  is_numeric($arg[1])) {
+	$o_format = $arg[0];
+	$asn = $arg[1];
+}
+else {
+	print("! URL error /<os>/<as_int> or /<as_int>");
+	exit(1);
+}
+
+print("! Generate for ". $o_format ." for ASN". $asn."\n");
+
+if (pfxlist_generate($o_format, $asn, $o_pfxstr, $o_pfxstr_v6, $o_pfxlen, $o_pfxlen_v6, $o_4, $o_6) < 0) {
+	printf("! Error generating prefix-list, aborting.\n");
+	exit(1);
+}
+
+ ?>

--- a/inc/pfxlist.inc
+++ b/inc/pfxlist.inc
@@ -154,7 +154,7 @@ function pfxlist_generate_cisco($pfxfile, $asn, $pfxstr, $pfxstr_v6, $pfxlen, $p
     $pfxname_v6 = sprintf($pfxstr_v6, $asn);
     global $cfg;
 
-    printf("conf t\n");
+    if($cfg['pfxgen']['default_send_cmd']) printf("conf t\n");
     if( $o_4 == 1 && $o_6 == 0 )
     {
         printf("no ip prefix-list %s\n", $pfxname);
@@ -181,7 +181,7 @@ function pfxlist_generate_cisco($pfxfile, $asn, $pfxstr, $pfxstr_v6, $pfxlen, $p
         {
             if ( $prefix[1] > $pfxlen )
                 continue;
-    
+
               printf("ip prefix-list %s permit %s/%d", $pfxname, $prefix[0], $prefix[1]);
               if ($prefix[1] < $pfxlen)
                   printf(" le %s", $pfxlen);
@@ -201,8 +201,8 @@ function pfxlist_generate_cisco($pfxfile, $asn, $pfxstr, $pfxstr_v6, $pfxlen, $p
         printf("\n");
     }
 
-    printf("end\n");
-    printf("write mem\n");
+    if($cfg['pfxgen']['default_send_cmd']) printf("end\n");
+    if($cfg['pfxgen']['default_send_cmd']) printf("write mem\n");
 
     return 0;
 }
@@ -215,21 +215,7 @@ function pfxlist_generate_iosxr($pfxfile, $asn, $pfxstr, $pfxstr_v6, $pfxlen, $p
     $pfx1st_v6 = 'Y';
     global $cfg;
 
-    printf("conf\n");
-    if( $o_4 == 1 && $o_6 == 0 )
-    {
-        printf("no prefix-set %s\n", $pfxname);
-    }
-    elseif( $o_6 == 1 && $o_4 == 0 )
-    {
-        printf("no prefix-set %s\n", $pfxname_v6);
-    }
-    else
-    {
-        printf("no prefix-set %s\n", $pfxname);
-        printf("no prefix-set %s\n", $pfxname_v6);
-    }
-
+    if($cfg['pfxgen']['default_send_cmd']) printf("conf\n");
     $skipcomma = false;
 
     while (!feof($pfxfile)) {
@@ -302,8 +288,10 @@ function pfxlist_generate_iosxr($pfxfile, $asn, $pfxstr, $pfxstr_v6, $pfxlen, $p
         printf("\n");
         printf("end-set\n");
     }
-    printf("commit\n");
-    printf("exit\n");
+    if($cfg['pfxgen']['default_send_cmd']) {
+      printf("commit\n");
+      printf("exit\n");
+    }
 
     return 0;
 }
@@ -361,7 +349,7 @@ function pfxlist_generate_extreme($pfxfile, $asn, $pfxstr, $pfxstr_v6, $pfxlen, 
         {
             if( $prefix[1] > $pfxlen_v6 )
                 continue;
-    
+
             printf("configure access-profile %s add %d permit ipaddress %s/%d", $pfxname_v6, $counter += 10, $prefix[0], $prefix[1]);
             if ($prefix[1] < $pfxlen_v6)
             {
@@ -386,7 +374,7 @@ function pfxlist_generate_force10($pfxfile, $asn, $pfxstr, $pfxstr_v6, $pfxlen, 
     $v4_list = $v6_list = array();
     global $cfg;
 
-    printf("conf t\n");
+    if($cfg['pfxgen']['default_send_cmd']) printf("conf t\n");
 
     while (!feof($pfxfile)) {
         if (!($line = rtrim(fgets($pfxfile, 64))))
@@ -426,8 +414,10 @@ function pfxlist_generate_force10($pfxfile, $asn, $pfxstr, $pfxstr_v6, $pfxlen, 
     pfxlist_print_force10($pfxname, $v4_list, 4);
     pfxlist_print_force10($pfxname_v6, $v6_list, 6);
 
-    printf("end\n");
-    printf("write mem\n");
+    if($cfg['pfxgen']['default_send_cmd']) {
+      printf("end\n");
+      printf("write mem\n");
+    }
 
     return 0;
 }
@@ -460,7 +450,7 @@ function pfxlist_generate_openbgpd($pfxfile, $asn, $pfxstr, $pfxstr_v6, $pfxlen,
     $v4_list = $v6_list = array();
     global $cfg;
 
-    // printf("conf t\n");
+    if($cfg['pfxgen']['default_send_cmd']) printf("conf t\n");
 
     while (!feof($pfxfile)) {
           if (!($line = rtrim(fgets($pfxfile, 64))))
@@ -606,7 +596,7 @@ function pfxlist_generate_huawei($pfxfile, $asn, $pfxstr, $pfxstr_v6, $pfxlen, $
         {
             if( $prefix[1] > $pfxlen )
                 continue;
-    
+
             printf("ip ip-prefix %s permit %s %d", $pfxname, $prefix[0], $prefix[1]);
             if ($prefix[0] == "0.0.0.0") {
                 printf(" match-network");
@@ -619,7 +609,7 @@ function pfxlist_generate_huawei($pfxfile, $asn, $pfxstr, $pfxstr_v6, $pfxlen, $
         {
             if( $prefix[1] > $pfxlen_v6 )
                 continue;
-        
+
             printf("ip ipv6-prefix %s permit %s %d", $pfxname_v6, $prefix[0], $prefix[1]);
             if ($prefix[0] == "::")
                 printf(" match-network");


### PR DESCRIPTION
I would like contribute another way for deploying large prefix lists. Instead of pushing the configuration, the prefix set can be pulled from the router itself like:

- `copy http://203.0.113.1/pfxgen/42 running-config` (default syntax)
- or
- `copy http://203.0.113.1/pfxgen/iosxr/42 running-config`

On the management station where irrpt is running, a working http server is nessessary. Sample nginx config:
```
   rewrite ^/pfxgen/(.*)$ /irrpt_pfxgen_http.php?$1 last;
   location ~ irrpt_pfxgen_http.php$ {
      include snippets/fastcgi-php.conf;
      root /opt/irrpt/bin;
      # With php-fpm:
      fastcgi_pass unix:/run/php/php-fpm.sock;
   }
```

The prefix lists can also be testen from any client (or monitoring systems) like 
```
curl http://217.11.222.212/pfxgen/iosxr/42
! Generate for iosxr for ASN15576
prefix-set PS-IPV4-AS15576
  63.246.32.0/20 le 32,
  65.22.19.0/24 le 32,
etc..
```

To accomplish this, i had to introduce a new default variable `$cfg['pfxgen']['default_send_cmd']) ` to give the possibility to disable commands like `conf t`etc. (default True, to avoid breaking changes)

- Test / verify other ios
- contribute to readme.md
-  ??

Let me know what you think. 